### PR TITLE
Interpolated normal calculation

### DIFF
--- a/Assets/Develop/Models/Bucket.fbx.meta
+++ b/Assets/Develop/Models/Bucket.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 2f544844c0be38c4798b17bce08fd07a
 ModelImporter:
-  serializedVersion: 21202
+  serializedVersion: 21300
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -32,7 +32,7 @@ ModelImporter:
     extraExposedTransformPaths: []
     extraUserProperties: []
     clipAnimations: []
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1
@@ -99,6 +99,7 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/Packages/ParticlePhysics/Runtime/Resources/Include/Terrain.cginc
+++ b/Packages/ParticlePhysics/Runtime/Resources/Include/Terrain.cginc
@@ -36,4 +36,22 @@ inline float GetInterpolatedHeight(float pos_x, float pos_z)
 	return dst + 0.1f;
 }
 
+// Normalmap‚ð•âŠ®‚·‚é
+inline float3 GetInterpolatedNormal(float pos_x, float pos_z)
+{
+	uint int_x = uint(pos_x);
+	uint int_z = uint(pos_z);
+
+	float dist_x = float(int_x + 1) - pos_x;
+	float dist_z = float(int_z + 1) - pos_z;
+
+	float3 norm0 = _TerrainBuffer[int_x + int_z * _Resolution].normal * dist_x * dist_z;
+	float3 norm1 = _TerrainBuffer[(int_x + 1) + int_z * _Resolution].normal * (1.0f - dist_x) * dist_z;
+	float3 norm2 = _TerrainBuffer[int_x + (int_z + 1) * _Resolution].normal * dist_x * (1.0f - dist_z);
+	float3 norm3 = _TerrainBuffer[(int_x + 1) + (int_z + 1) * _Resolution].normal * (1.0f - dist_x) * (1.0f - dist_z);
+
+	float3 norm = norm0 + norm1 + norm2 + norm3;
+	return norm / length(norm);
+}
+
 #endif

--- a/Packages/ParticlePhysics/Runtime/Resources/MolecularDynamics.compute
+++ b/Packages/ParticlePhysics/Runtime/Resources/MolecularDynamics.compute
@@ -211,7 +211,7 @@ void IntegrateCS(uint3 dispatchID : SV_DispatchThreadID)
 	if (particle.position.y < height)
 	{
 		particle.position.y = height;
-		norm = _TerrainBuffer[pos.x + pos.y * _Resolution].normal; // 法線ベクトル
+		norm = GetInterpolatedNormal(particle.position.x * _Ratio.x, particle.position.z * _Ratio.z); // 法線ベクトル
 		particle.velocity = particle.velocity + dot(-particle.velocity, norm) * norm; // 速度ベクトルを壁に沿った向きに変換
 		particle.velocity = _Friction * particle.velocity; // 摩擦
 	}


### PR DESCRIPTION
https://github.com/qoopen0815/ParticlePhysics/issues/18 の修正です。

変更したスクリプトは dev/object-collision では動作確認を行いましたが、 dev/physics-algorithm ブランチでは動作確認が出来ていません(再生ボタンを押しても粒子が出現しない(?))。

変更内容
* Terrain.cginc に周囲4点の法線の重み付き平均を取る関数 GetInterpolatedNormal() を追加
float3周りにあまり詳しくないため、行列計算ではなくベタ書きになっています。

* MolecularDynamics.compute 内 IntegrateCS() での計算に用いる法線に、上記のGetInterpolatedNormal() を用いるように変更。

* Bucket モデルの設定 isReadble を True に変更
再生時に Mesh 読み取りエラーが発生したため。

* SampleScene.scene にバケットオブジェクトを追加
dev/object-collision ブランチでの実験の際、ParticlePhysicsExample.cs の Objects[] が空の際にエラーが発生していたため。

